### PR TITLE
feat: Add option to disable edge label rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ cyInstance.nodeEdgeHtmlLabel([
         edgehtmlLocation: 'start', //location on edge to render html. Can be 'start','end','center'. 'center' will be default
         edgehtmlTiltPoint1: 'sourceNode', // first point to get angle of tilt for html.Can be 'sourceNode','targetNode', control point (i.e 0,1,2...)
         edgehtmlTiltPoint2: 'targetNode', // second point to get angle of tilt for html.Can be 'sourceNode','targetNode', control point (i.e 0,1,2...)
+        disableLabelRotation: false, // Optional: Set to true to prevent the edge label from rotating with the edge. Defaults to false (label rotates).
         tpl(data: any) {
           return '<div>this is div</div>';
           // your html template here

--- a/src/cytoscape-node-edge-html-label.ts
+++ b/src/cytoscape-node-edge-html-label.ts
@@ -14,6 +14,7 @@ interface CytoscapeNodeHtmlParams {
   edgehtmlTiltPoint1?: 'sourceNode' | 'targetNode' | number;
   edgehtmlTiltPoint2?: 'sourceNode' | 'targetNode' | number;
   edgehtmlLocation?: 'start' | 'end' | 'center';
+  disableLabelRotation?: boolean;
   tpl?: (d: any) => string;
 }
 
@@ -247,7 +248,7 @@ interface CytoscapeContainerParams {
         }
         const valRel = `translate(${this._align[2]}%,${this._align[3]}%) `;
         const valAbs = `translate(${x.toFixed(2)}px,${y.toFixed(2)}px) `;
-        const val = valRel + valAbs + `rotate(${angleDeg}deg)`;
+        const val = valRel + valAbs + (this._params.disableLabelRotation ? '' : `rotate(${angleDeg}deg)`);
         const stl = <any>this._node.style;
         stl.webkitTransform = val;
         stl.msTransform = val;


### PR DESCRIPTION
This commit introduces a new boolean option `disableLabelRotation` to the `CytoscapeNodeHtmlParams` interface. This option allows users to prevent HTML labels associated with edges from rotating to align with the edge's angle.

When `disableLabelRotation` is set to `true` in the parameters for an edge label, the label will maintain a 0-degree rotation (i.e., remain horizontal), irrespective of the edge's orientation. If the option is `false` or not provided, the default behavior (labels rotate with the edge) is preserved.

This feature provides greater control over the visual presentation of edge labels, which can be particularly useful for improving readability in graphs with many overlapping edges or when labels are lengthy.

Example usage:
```javascript
cy.nodeHtmlLabel([
  {
    query: 'edge', // Apply to edges
    tpl: (data) => `<span>${data.id}</span>`,
    disableLabelRotation: true // This will keep the edge label horizontal
  }
]);